### PR TITLE
Set the "autoescape" option to true for Jinja2 to prevent XSS

### DIFF
--- a/app.py
+++ b/app.py
@@ -18,7 +18,6 @@ print(terminalASCII())
 # Print a line breaker and a message that the app is starting
 Log.info("Starting...")
 
-
 # Importing necessary modules and classes
 from flask_wtf.csrf import (
     CSRFError,
@@ -198,6 +197,9 @@ app = Flask(
     static_folder=STATIC_FOLDER,  # The folder where the static files(*.js/*.css) are stored
     template_folder=TEMPLATE_FOLDER,  # The folder where the Jinja(*.html.jinja) templates are stored
 )
+
+# Enable autoescape for all rendered jinja pages irrespective of file extension.
+app.jinja_options["autoescape"] = True
 
 # Set the secret key and the session permanent flag for the app
 app.secret_key = APP_SECRET_KEY  # The secret key for the app


### PR DESCRIPTION
## Explanation of changes
Due to how Flask works, the option to autoescape HTML tags is enabled by default ONLY if the rendered page ends with `.html`, `.htm`, `.xml`, `.xhtml`, as well as `.svg` when using `render_template()` ([Source](https://flask.palletsprojects.com/en/stable/templating/#jinja-setup)) .

The issue is that most of, if not all the templates in this project end with the extension `.jinja`.

Enabling this option forces HTML to be autoescaped irrespective of the file extension. I believe this is the cleanest way to handle the vast majority of XSS vulnerabilities in this application.

---

## Examples of XSS before the fix
### Searching in the username field
![flaskblog_XSS_1](https://github.com/user-attachments/assets/756ee95c-7210-47d2-a95a-675581b9b308)

### Putting it as a blog title (I believe any other of these fields would also lead to XSS)
![flaskblog_XSS_2](https://github.com/user-attachments/assets/f090203f-1929-4b65-b765-3b7326d57a83)

### Putting a username with script tags in it
![flaskblog_XSS_3](https://github.com/user-attachments/assets/70ca9bc0-7ea3-4aa9-9e7c-6c8077e768c4)

---

## XSS examples after the fix
![flaskblog_XSS_after_fix_1](https://github.com/user-attachments/assets/52a2af68-4f59-4082-8b54-385eb1a651c1)
![flaskblog_XSS_after_fix_2](https://github.com/user-attachments/assets/57d291d8-0082-47c7-8235-ed0477fe9559)
![flaskblog_XSS_after_fix_3](https://github.com/user-attachments/assets/78497a66-e050-452a-80c5-5d981ec7efdd)

---

## Further comments:

This pull request fixes one of issues highlighted by @DogukanUrker in [issue 130](https://github.com/DogukanUrker/flaskBlog/issues/130).

I hope my contribution is welcome! :grin: 

 - Teloshav
 
 Closes #130 