### PR TITLE
Add abstract support for posts

### DIFF
--- a/app/routes/createPost.py
+++ b/app/routes/createPost.py
@@ -60,7 +60,23 @@ def createPost():
                 connection.set_trace_callback(Log.database)
                 cursor = connection.cursor()
                 cursor.execute(
-                    "insert into posts(title,tags,content,banner,author,views,timeStamp,lastEditTimeStamp,category,urlID,abstract) values(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                    """
+                    INSERT INTO posts (
+                        title,
+                        tags,
+                        content,
+                        banner,
+                        author,
+                        views,
+                        timeStamp,
+                        lastEditTimeStamp,
+                        category,
+                        urlID,
+                        abstract
+                    ) VALUES (
+                        ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+                    )
+                    """,
                     (
                         postTitle,
                         postTags,

--- a/app/routes/createPost.py
+++ b/app/routes/createPost.py
@@ -39,11 +39,12 @@ def createPost():
         if request.method == "POST":
             postTitle = request.form["postTitle"]
             postTags = request.form["postTags"]
+            postAbstract = request.form["postAbstract"]
             postContent = request.form["postContent"]
             postBanner = request.files["postBanner"].read()
             postCategory = request.form["postCategory"]
 
-            if postContent == "":
+            if postContent == "" or postAbstract == "":
                 flashMessage(
                     page="createPost",
                     message="empty",
@@ -59,8 +60,7 @@ def createPost():
                 connection.set_trace_callback(Log.database)
                 cursor = connection.cursor()
                 cursor.execute(
-                    "insert into posts(title,tags,content,banner,author,views,timeStamp,lastEditTimeStamp,category,urlID) \
-                                values(?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                    "insert into posts(title,tags,content,banner,author,views,timeStamp,lastEditTimeStamp,category,urlID,abstract) values(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                     (
                         postTitle,
                         postTags,
@@ -72,6 +72,7 @@ def createPost():
                         currentTimeStamp(),
                         postCategory,
                         generateurlID(),
+                        postAbstract,
                     ),
                 )
                 connection.commit()

--- a/app/routes/editPost.py
+++ b/app/routes/editPost.py
@@ -68,6 +68,7 @@ def editPost(urlID):
                 form = CreatePostForm(request.form)
                 form.postTitle.data = post[1]
                 form.postTags.data = post[2]
+                form.postAbstract.data = post[11]
                 form.postContent.data = post[3]
                 form.postCategory.data = post[9]
 
@@ -75,10 +76,11 @@ def editPost(urlID):
                     postTitle = request.form["postTitle"]
                     postTags = request.form["postTags"]
                     postContent = request.form["postContent"]
+                    postAbstract = request.form["postAbstract"]
                     postCategory = request.form["postCategory"]
                     postBanner = request.files["postBanner"].read()
 
-                    if postContent == "":
+                    if postContent == "" or postAbstract == "":
                         flashMessage(
                             page="editPost",
                             message="empty",
@@ -103,6 +105,10 @@ def editPost(urlID):
                         cursor.execute(
                             """update posts set content = ? where id = ? """,
                             (postContent, post[0]),
+                        )
+                        cursor.execute(
+                            """update posts set abstract = ? where id = ? """,
+                            (postAbstract, post[0]),
                         )
                         cursor.execute(
                             """update posts set category = ? where id = ? """,

--- a/app/routes/post.py
+++ b/app/routes/post.py
@@ -160,6 +160,7 @@ def post(urlID=None, slug=None):
             id=post[0],
             title=post[1],
             tags=post[2],
+            abstract=post[11],
             content=post[3],
             author=post[5],
             views=post[6],

--- a/app/templates/components/postCardMacro.html
+++ b/app/templates/components/postCardMacro.html
@@ -19,9 +19,9 @@
             >{{ post[1] }}</a
         >
 
-        <div class="overflow-hidden flex-grow markdown-content compact">
-            <span class="text-sm leading-relaxed line-clamp-4">
-                {{ render_markdown(post[11][:200]) }}
+        <div class="overflow-hidden flex-grow">
+            <span class="text-sm leading-relaxed line-clamp-4 break-words">
+                {{ post[11] }}
             </span>
         </div>
 

--- a/app/templates/components/postCardMacro.html
+++ b/app/templates/components/postCardMacro.html
@@ -21,7 +21,7 @@
 
         <div class="overflow-hidden flex-grow markdown-content compact">
             <span class="text-sm leading-relaxed line-clamp-4">
-                {{ render_markdown(post[11]) }}
+                {{ render_markdown(post[11][:200]) }}
             </span>
         </div>
 

--- a/app/templates/components/postCardMacro.html
+++ b/app/templates/components/postCardMacro.html
@@ -21,7 +21,7 @@
 
         <div class="overflow-hidden flex-grow markdown-content compact">
             <span class="text-sm leading-relaxed line-clamp-4">
-                {{ render_markdown(post[3][:200]) }}
+                {{ render_markdown(post[11]) }}
             </span>
         </div>
 

--- a/app/templates/createPost.html
+++ b/app/templates/createPost.html
@@ -11,6 +11,9 @@
         }} {{
         form.postTags(autocomplete="off",placeholder=translations.createPost.tags)
         }}
+        {{
+        form.postAbstract(autocomplete="off",placeholder=translations.createPost.abstractPlaceholder)
+        }}
         <p class="text-xs text-center w-fit mx-auto mb-2">
             {{ translations.createPost.separate }}
         </p>

--- a/app/templates/editPost.html
+++ b/app/templates/editPost.html
@@ -11,6 +11,9 @@
         }} {{
         form.postTags(autocomplete="off",placeholder=translations.editPost.tags)
         }}
+        {{
+        form.postAbstract(autocomplete="off",placeholder=translations.editPost.abstractPlaceholder)
+        }}
         <p class="text-xs text-center w-fit mx-auto mb-2">
             {{translations.editPost.separate}}
         </p>

--- a/app/templates/post.html
+++ b/app/templates/post.html
@@ -12,16 +12,10 @@
 <meta name="keywords" content="{{ tags }}" />
 <meta name="author" content="{{ author }}" />
 <meta property="og:url" content="{{ blogPostUrl }}" />
-<meta
-    property="og:description"
-    content="{{ abstract[:100] | striptags + '...' }}"
-/>
+<meta property="og:description" content="{{ abstract | striptags + '...' }}" />
 <meta name="twitter:site" content="{{ appName }}" />
 <meta name="twitter:title" content="{{ title }}" />
-<meta
-    name="twitter:description"
-    content="{{ abstract[:100] | striptags + '...' }}"
-/>
+<meta name="twitter:description" content="{{ abstract | striptags + '...' }}" />
 <meta
     name="twitter:image"
     content="{{
@@ -29,8 +23,6 @@
   }}{{ url_for('returnPostBanner.returnPostBanner', postID = id) }}"
 />
 <meta property="og:site_name" content="{{ appName }}" />
-
-
 
 {% endblock head %} {% block body %}
 <script>
@@ -66,9 +58,11 @@
         {% endif %}
     </div>
 
-    <div class="markdown-content">
-        {{ render_markdown(content) }}
-    </div>
+    <div class="text-center font-sm max-w-full">{{ abstract }}</div>
+
+    <div class="divider"></div>
+
+    <div class="markdown-content">{{ render_markdown(content) }}</div>
 
     <div class="select-none">
         <div class="flex w-full justify-between my-1">
@@ -177,7 +171,9 @@
                 {% endif %}
             </div>
             <p class="break-words ml-8">
-                <i class="ti ti-corner-down-right mr-1 text-xl inline-block"></i>
+                <i
+                    class="ti ti-corner-down-right mr-1 text-xl inline-block"
+                ></i>
                 {{ comment[2] | e }}
             </p>
         </div>

--- a/app/templates/post.html
+++ b/app/templates/post.html
@@ -14,13 +14,13 @@
 <meta property="og:url" content="{{ blogPostUrl }}" />
 <meta
     property="og:description"
-    content="{{ content[:100] | striptags + '...' | safe }}"
+    content="{{ abstract[:100] | striptags + '...' }}"
 />
 <meta name="twitter:site" content="{{ appName }}" />
 <meta name="twitter:title" content="{{ title }}" />
 <meta
     name="twitter:description"
-    content="{{ content[:100] | striptags + '...' | safe }}"
+    content="{{ abstract[:100] | striptags + '...' }}"
 />
 <meta
     name="twitter:image"

--- a/app/translations/de.json
+++ b/app/translations/de.json
@@ -133,8 +133,8 @@
     "separate": "(Trennen Sie die Tags mit Kommas)",
     "save": "Änderungen speichern",
     "bannerPlaceholder": "Beitragsbanner",
-    "abstract": "Abstract",
-    "abstractPlaceholder": "post abstract"
+    "abstract": "Zusammenfassung",
+    "abstractPlaceholder": "Beitragszusammenfassung"
   },
   "login": {
     "title": "Anmelden",

--- a/app/translations/de.json
+++ b/app/translations/de.json
@@ -98,8 +98,8 @@
     "tags": "Tags",
     "post": "Beitrag veröffentlichen",
     "separate": "(Trennen Sie die Tags mit Kommas)",
-    "abstract": "Abstract",
-    "abstractPlaceholder": "post abstract"
+    "abstract": "Zusammenfassung",
+    "abstractPlaceholder": "Beitragszusammenfassung"
   },
   "csrfError": {
     "reason": "Grund",

--- a/app/translations/de.json
+++ b/app/translations/de.json
@@ -97,7 +97,9 @@
     "bannerPlaceholder": "Beitragsbanner",
     "tags": "Tags",
     "post": "Beitrag veröffentlichen",
-    "separate": "(Trennen Sie die Tags mit Kommas)"
+    "separate": "(Trennen Sie die Tags mit Kommas)",
+    "abstract": "Abstract",
+    "abstractPlaceholder": "post abstract"
   },
   "csrfError": {
     "reason": "Grund",
@@ -130,7 +132,9 @@
     "tags": "Tags",
     "separate": "(Trennen Sie die Tags mit Kommas)",
     "save": "Änderungen speichern",
-    "bannerPlaceholder": "Beitragsbanner"
+    "bannerPlaceholder": "Beitragsbanner",
+    "abstract": "Abstract",
+    "abstractPlaceholder": "post abstract"
   },
   "login": {
     "title": "Anmelden",

--- a/app/translations/en.json
+++ b/app/translations/en.json
@@ -97,7 +97,9 @@
     "bannerPlaceholder": "post banner",
     "tags": "tags",
     "post": "Post",
-    "separate": "(Separate tags with commas)"
+    "separate": "(Separate tags with commas)",
+    "abstract": "Abstract",
+    "abstractPlaceholder": "post abstract"
   },
   "csrfError": {
     "reason": "Reason",
@@ -130,7 +132,9 @@
     "tags": "tags",
     "separate": "(Separate tags with commas)",
     "save": "Save Changes",
-    "bannerPlaceholder": "post banner"
+    "bannerPlaceholder": "post banner",
+    "abstract": "Abstract",
+    "abstractPlaceholder": "post abstract"
   },
   "login": {
     "title": "Login",
@@ -320,9 +324,9 @@
     "contact": "Contact Us",
     "contactText": "If you have any questions or suggestions about our Privacy Policy, do not hesitate to contact us. Mail:"
   },
-  "analytics":{
+  "analytics": {
     "title": "Analytics",
-    "goToPage" : "Go to page",
+    "goToPage": "Go to page",
     "totalVisitor": "Total Visitor",
     "todaysVisitor": "Today's Visitor",
     "category": "Category",

--- a/app/translations/es.json
+++ b/app/translations/es.json
@@ -99,7 +99,7 @@
     "post": "Publicar",
     "separate": "(Separe las etiquetas con comas)",
     "abstract": "Resumen",
-    "abstractPlaceholder": "post abstract"
+    "abstractPlaceholder": "resumen del post"
   },
   "csrfError": {
     "reason": "Razón",
@@ -133,8 +133,8 @@
     "separate": "(Separe las etiquetas con comas)",
     "save": "Guardar Cambios",
     "bannerPlaceholder": "banner de la publicación",
-    "abstract": "Abstract",
-    "abstractPlaceholder": "post abstract"
+    "abstract": "Resumen",
+    "abstractPlaceholder": "resumen del post"
   },
   "login": {
     "title": "Iniciar Sesión",

--- a/app/translations/es.json
+++ b/app/translations/es.json
@@ -97,7 +97,9 @@
     "bannerPlaceholder": "banner de la publicación",
     "tags": "etiquetas",
     "post": "Publicar",
-    "separate": "(Separe las etiquetas con comas)"
+    "separate": "(Separe las etiquetas con comas)",
+    "abstract": "Abstract",
+    "abstractPlaceholder": "post abstract"
   },
   "csrfError": {
     "reason": "Razón",
@@ -130,7 +132,9 @@
     "tags": "etiquetas",
     "separate": "(Separe las etiquetas con comas)",
     "save": "Guardar Cambios",
-    "bannerPlaceholder": "banner de la publicación"
+    "bannerPlaceholder": "banner de la publicación",
+    "abstract": "Abstract",
+    "abstractPlaceholder": "post abstract"
   },
   "login": {
     "title": "Iniciar Sesión",

--- a/app/translations/es.json
+++ b/app/translations/es.json
@@ -98,7 +98,7 @@
     "tags": "etiquetas",
     "post": "Publicar",
     "separate": "(Separe las etiquetas con comas)",
-    "abstract": "Abstract",
+    "abstract": "Resumen",
     "abstractPlaceholder": "post abstract"
   },
   "csrfError": {

--- a/app/translations/fr.json
+++ b/app/translations/fr.json
@@ -97,7 +97,9 @@
     "bannerPlaceholder": "bannière de l'article",
     "tags": "étiquettes",
     "post": "Publier",
-    "separate": "(Séparez les étiquettes par des virgules)"
+    "separate": "(Séparez les étiquettes par des virgules)",
+    "abstract": "Abstract",
+    "abstractPlaceholder": "post abstract"
   },
   "csrfError": {
     "reason": "Raison",
@@ -130,7 +132,9 @@
     "tags": "étiquettes",
     "separate": "(Séparez les étiquettes par des virgules)",
     "save": "Enregistrer les modifications",
-    "bannerPlaceholder": "bannière de l'article"
+    "bannerPlaceholder": "bannière de l'article",
+    "abstract": "Abstract",
+    "abstractPlaceholder": "post abstract"
   },
   "login": {
     "title": "Connexion",

--- a/app/translations/fr.json
+++ b/app/translations/fr.json
@@ -133,8 +133,8 @@
     "separate": "(Séparez les étiquettes par des virgules)",
     "save": "Enregistrer les modifications",
     "bannerPlaceholder": "bannière de l'article",
-    "abstract": "Abstract",
-    "abstractPlaceholder": "post abstract"
+    "abstract": "Résumé",
+    "abstractPlaceholder": "résumé de l'article"
   },
   "login": {
     "title": "Connexion",

--- a/app/translations/fr.json
+++ b/app/translations/fr.json
@@ -98,8 +98,8 @@
     "tags": "étiquettes",
     "post": "Publier",
     "separate": "(Séparez les étiquettes par des virgules)",
-    "abstract": "Abstract",
-    "abstractPlaceholder": "post abstract"
+    "abstract": "Résumé",
+    "abstractPlaceholder": "résumé de l'article"
   },
   "csrfError": {
     "reason": "Raison",

--- a/app/translations/ja.json
+++ b/app/translations/ja.json
@@ -133,8 +133,8 @@
     "separate": "(タグはカンマで区切ってください)",
     "save": "変更を保存",
     "bannerPlaceholder": "投稿バナー",
-    "abstract": "Abstract",
-    "abstractPlaceholder": "post abstract"
+    "abstract": "概要",
+    "abstractPlaceholder": "投稿の概要"
   },
   "login": {
     "title": "ログイン",

--- a/app/translations/ja.json
+++ b/app/translations/ja.json
@@ -97,9 +97,10 @@
     "bannerPlaceholder": "投稿バナー",
     "tags": "タグ",
     "post": "投稿",
-    "separate": "(タグはカンマで区切ってください)"
+    "separate": "(タグはカンマで区切ってください)",
+    "abstract": "Abstract",
+    "abstractPlaceholder": "post abstract"
   },
-
   "csrfError": {
     "reason": "理由",
     "description": "同じフォームを再度記入してください。"
@@ -131,7 +132,9 @@
     "tags": "タグ",
     "separate": "(タグはカンマで区切ってください)",
     "save": "変更を保存",
-    "bannerPlaceholder": "投稿バナー"
+    "bannerPlaceholder": "投稿バナー",
+    "abstract": "Abstract",
+    "abstractPlaceholder": "post abstract"
   },
   "login": {
     "title": "ログイン",

--- a/app/translations/ja.json
+++ b/app/translations/ja.json
@@ -98,8 +98,8 @@
     "tags": "タグ",
     "post": "投稿",
     "separate": "(タグはカンマで区切ってください)",
-    "abstract": "Abstract",
-    "abstractPlaceholder": "post abstract"
+    "abstract": "概要",
+    "abstractPlaceholder": "投稿の概要"
   },
   "csrfError": {
     "reason": "理由",

--- a/app/translations/pl.json
+++ b/app/translations/pl.json
@@ -99,7 +99,7 @@
     "post": "Opublikuj",
     "separate": "(Oddziel tagi przecinkami)",
     "abstract": "Abstrakt",
-    "abstractPlaceholder": "post abstract"
+    "abstractPlaceholder": "abstrakt postu"
   },
   "csrfError": {
     "reason": "Powód",
@@ -133,8 +133,8 @@
     "separate": "(Oddziel tagi przecinkami)",
     "save": "Zapisz zmiany",
     "bannerPlaceholder": "baner posta",
-    "abstract": "Abstract",
-    "abstractPlaceholder": "post abstract"
+    "abstract": "Abstrakt",
+    "abstractPlaceholder": "abstrakt postu"
   },
   "login": {
     "title": "Logowanie",

--- a/app/translations/pl.json
+++ b/app/translations/pl.json
@@ -98,7 +98,7 @@
     "tags": "tagi",
     "post": "Opublikuj",
     "separate": "(Oddziel tagi przecinkami)",
-    "abstract": "Abstract",
+    "abstract": "Abstrakt",
     "abstractPlaceholder": "post abstract"
   },
   "csrfError": {

--- a/app/translations/pl.json
+++ b/app/translations/pl.json
@@ -97,7 +97,9 @@
     "bannerPlaceholder": "baner posta",
     "tags": "tagi",
     "post": "Opublikuj",
-    "separate": "(Oddziel tagi przecinkami)"
+    "separate": "(Oddziel tagi przecinkami)",
+    "abstract": "Abstract",
+    "abstractPlaceholder": "post abstract"
   },
   "csrfError": {
     "reason": "Powód",
@@ -130,7 +132,9 @@
     "tags": "tagi",
     "separate": "(Oddziel tagi przecinkami)",
     "save": "Zapisz zmiany",
-    "bannerPlaceholder": "baner posta"
+    "bannerPlaceholder": "baner posta",
+    "abstract": "Abstract",
+    "abstractPlaceholder": "post abstract"
   },
   "login": {
     "title": "Logowanie",

--- a/app/translations/pt.json
+++ b/app/translations/pt.json
@@ -97,7 +97,9 @@
     "bannerPlaceholder": "banner do post",
     "tags": "tags",
     "post": "Publicar",
-    "separate": "(Separe as tags com vírgulas)"
+    "separate": "(Separe as tags com vírgulas)",
+    "abstract": "Abstract",
+    "abstractPlaceholder": "post abstract"
   },
   "csrfError": {
     "reason": "Motivo",
@@ -130,7 +132,9 @@
     "tags": "tags",
     "separate": "(Separe as tags com vírgulas)",
     "save": "Salvar Alterações",
-    "bannerPlaceholder": "banner do post"
+    "bannerPlaceholder": "banner do post",
+    "abstract": "Abstract",
+    "abstractPlaceholder": "post abstract"
   },
   "login": {
     "title": "Entrar",

--- a/app/translations/pt.json
+++ b/app/translations/pt.json
@@ -98,7 +98,7 @@
     "tags": "tags",
     "post": "Publicar",
     "separate": "(Separe as tags com vírgulas)",
-    "abstract": "Abstract",
+    "abstract": "Resumo",
     "abstractPlaceholder": "post abstract"
   },
   "csrfError": {

--- a/app/translations/pt.json
+++ b/app/translations/pt.json
@@ -99,7 +99,7 @@
     "post": "Publicar",
     "separate": "(Separe as tags com vírgulas)",
     "abstract": "Resumo",
-    "abstractPlaceholder": "post abstract"
+    "abstractPlaceholder": "resumo do post"
   },
   "csrfError": {
     "reason": "Motivo",

--- a/app/translations/pt.json
+++ b/app/translations/pt.json
@@ -133,8 +133,8 @@
     "separate": "(Separe as tags com vírgulas)",
     "save": "Salvar Alterações",
     "bannerPlaceholder": "banner do post",
-    "abstract": "Abstract",
-    "abstractPlaceholder": "post abstract"
+    "abstract": "Resumo",
+    "abstractPlaceholder": "resumo do post"
   },
   "login": {
     "title": "Entrar",

--- a/app/translations/ru.json
+++ b/app/translations/ru.json
@@ -99,7 +99,7 @@
     "post": "Опубликовать",
     "separate": "(Разделяйте теги запятыми)",
     "abstract": "Аннотация",
-    "abstractPlaceholder": "post abstract"
+    "abstractPlaceholder": "аннотация поста"
   },
   "csrfError": {
     "reason": "Причина",
@@ -133,8 +133,8 @@
     "separate": "(Разделяйте теги запятыми)",
     "save": "Сохранить изменения",
     "bannerPlaceholder": "баннер поста",
-    "abstract": "Abstract",
-    "abstractPlaceholder": "post abstract"
+    "abstract": "Аннотация",
+    "abstractPlaceholder": "аннотация поста"
   },
   "login": {
     "title": "Вход",

--- a/app/translations/ru.json
+++ b/app/translations/ru.json
@@ -97,7 +97,9 @@
     "bannerPlaceholder": "баннер поста",
     "tags": "теги",
     "post": "Опубликовать",
-    "separate": "(Разделяйте теги запятыми)"
+    "separate": "(Разделяйте теги запятыми)",
+    "abstract": "Abstract",
+    "abstractPlaceholder": "post abstract"
   },
   "csrfError": {
     "reason": "Причина",
@@ -130,7 +132,9 @@
     "tags": "теги",
     "separate": "(Разделяйте теги запятыми)",
     "save": "Сохранить изменения",
-    "bannerPlaceholder": "баннер поста"
+    "bannerPlaceholder": "баннер поста",
+    "abstract": "Abstract",
+    "abstractPlaceholder": "post abstract"
   },
   "login": {
     "title": "Вход",

--- a/app/translations/ru.json
+++ b/app/translations/ru.json
@@ -98,7 +98,7 @@
     "tags": "теги",
     "post": "Опубликовать",
     "separate": "(Разделяйте теги запятыми)",
-    "abstract": "Abstract",
+    "abstract": "Аннотация",
     "abstractPlaceholder": "post abstract"
   },
   "csrfError": {

--- a/app/translations/tr.json
+++ b/app/translations/tr.json
@@ -97,7 +97,9 @@
     "bannerPlaceholder": "gönderi afişi",
     "tags": "etiketler",
     "post": "Gönder",
-    "separate": "(Etiketleri virgülle ayırın)"
+    "separate": "(Etiketleri virgülle ayırın)",
+    "abstract": "Abstract",
+    "abstractPlaceholder": "post abstract"
   },
   "csrfError": {
     "reason": "Sebep",
@@ -130,7 +132,9 @@
     "tags": "etiketler",
     "separate": "(Etiketleri virgülle ayırın)",
     "save": "Değişiklikleri Kaydet",
-    "bannerPlaceholder": "gönderi afişi"
+    "bannerPlaceholder": "gönderi afişi",
+    "abstract": "Abstract",
+    "abstractPlaceholder": "post abstract"
   },
   "login": {
     "title": "Giriş Yap",

--- a/app/translations/tr.json
+++ b/app/translations/tr.json
@@ -98,8 +98,8 @@
     "tags": "etiketler",
     "post": "Gönder",
     "separate": "(Etiketleri virgülle ayırın)",
-    "abstract": "Abstract",
-    "abstractPlaceholder": "post abstract"
+    "abstract": "Özet",
+    "abstractPlaceholder": "gönderi özeti"
   },
   "csrfError": {
     "reason": "Sebep",

--- a/app/translations/tr.json
+++ b/app/translations/tr.json
@@ -133,8 +133,8 @@
     "separate": "(Etiketleri virgülle ayırın)",
     "save": "Değişiklikleri Kaydet",
     "bannerPlaceholder": "gönderi afişi",
-    "abstract": "Abstract",
-    "abstractPlaceholder": "post abstract"
+    "abstract": "Özet",
+    "abstractPlaceholder": "gönderi özeti"
   },
   "login": {
     "title": "Giriş Yap",

--- a/app/translations/uk.json
+++ b/app/translations/uk.json
@@ -133,7 +133,7 @@
     "separate": "(Розділяйте теги комами)",
     "save": "Зберегти зміни",
     "bannerPlaceholder": "банер поста",
-    "abstract": "Abstract",
+    "abstract": "Анотація",
     "abstractPlaceholder": "post abstract"
   },
   "login": {

--- a/app/translations/uk.json
+++ b/app/translations/uk.json
@@ -97,7 +97,9 @@
     "bannerPlaceholder": "банер поста",
     "tags": "теги",
     "post": "Опублікувати",
-    "separate": "(Розділяйте теги комами)"
+    "separate": "(Розділяйте теги комами)",
+    "abstract": "Abstract",
+    "abstractPlaceholder": "post abstract"
   },
   "csrfError": {
     "reason": "Причина",
@@ -130,7 +132,9 @@
     "tags": "теги",
     "separate": "(Розділяйте теги комами)",
     "save": "Зберегти зміни",
-    "bannerPlaceholder": "банер поста"
+    "bannerPlaceholder": "банер поста",
+    "abstract": "Abstract",
+    "abstractPlaceholder": "post abstract"
   },
   "login": {
     "title": "Увійти",

--- a/app/translations/uk.json
+++ b/app/translations/uk.json
@@ -98,8 +98,8 @@
     "tags": "теги",
     "post": "Опублікувати",
     "separate": "(Розділяйте теги комами)",
-    "abstract": "Abstract",
-    "abstractPlaceholder": "post abstract"
+    "abstract": "Анотація",
+    "abstractPlaceholder": "Анотація поста"
   },
   "csrfError": {
     "reason": "Причина",

--- a/app/translations/uk.json
+++ b/app/translations/uk.json
@@ -134,7 +134,7 @@
     "save": "Зберегти зміни",
     "bannerPlaceholder": "банер поста",
     "abstract": "Анотація",
-    "abstractPlaceholder": "post abstract"
+    "abstractPlaceholder": "анотація поста"
   },
   "login": {
     "title": "Увійти",

--- a/app/translations/zh.json
+++ b/app/translations/zh.json
@@ -96,7 +96,9 @@
     "bannerPlaceholder": "帖子横幅",
     "tags": "标签",
     "post": "发布帖子",
-    "separate": "(用逗号分隔标签)"
+    "separate": "(用逗号分隔标签)",
+    "abstract": "Abstract",
+    "abstractPlaceholder": "post abstract"
   },
   "csrfError": {
     "reason": "原因",
@@ -129,7 +131,9 @@
     "tags": "标签",
     "separate": "(用逗号分隔标签)",
     "save": "保存更改",
-    "bannerPlaceholder": "帖子横幅"
+    "bannerPlaceholder": "帖子横幅",
+    "abstract": "Abstract",
+    "abstractPlaceholder": "post abstract"
   },
   "login": {
     "title": "登录",

--- a/app/translations/zh.json
+++ b/app/translations/zh.json
@@ -132,8 +132,8 @@
     "separate": "(用逗号分隔标签)",
     "save": "保存更改",
     "bannerPlaceholder": "帖子横幅",
-    "abstract": "Abstract",
-    "abstractPlaceholder": "post abstract"
+    "abstract": "摘要",
+    "abstractPlaceholder": "帖子摘要"
   },
   "login": {
     "title": "登录",

--- a/app/translations/zh.json
+++ b/app/translations/zh.json
@@ -97,8 +97,8 @@
     "tags": "标签",
     "post": "发布帖子",
     "separate": "(用逗号分隔标签)",
-    "abstract": "Abstract",
-    "abstractPlaceholder": "post abstract"
+    "abstract": "摘要",
+    "abstractPlaceholder": "帖子摘要"
   },
   "csrfError": {
     "reason": "原因",

--- a/app/utils/dbChecker.py
+++ b/app/utils/dbChecker.py
@@ -160,6 +160,7 @@ def postsTable():
             "lastEditTimeStamp" integer,
             "category"  text not null,
             "urlID" TEXT NOT NULL,
+            "abstract" text not null,
             primary key("id" autoincrement)
         );"""
 

--- a/app/utils/dbChecker.py
+++ b/app/utils/dbChecker.py
@@ -160,7 +160,7 @@ def postsTable():
             "lastEditTimeStamp" integer,
             "category"  text not null,
             "urlID" TEXT NOT NULL,
-            "abstract" text not null,
+            "abstract" text not null default "",
             primary key("id" autoincrement)
         );"""
 

--- a/app/utils/forms/CreatePostForm.py
+++ b/app/utils/forms/CreatePostForm.py
@@ -29,7 +29,7 @@ class CreatePostForm(Form):
 
     postAbstract = TextAreaField(
         "Post Abstract",
-        [validators.Length(min=50, max=300), validators.InputRequired()],
+        [validators.Length(min=150, max=200), validators.InputRequired()],
     )
 
     postContent = TextAreaField(

--- a/app/utils/forms/CreatePostForm.py
+++ b/app/utils/forms/CreatePostForm.py
@@ -27,6 +27,11 @@ class CreatePostForm(Form):
         [validators.InputRequired()],
     )
 
+    postAbstract = TextAreaField(
+        "Post Abstract",
+        [validators.Length(min=50, max=300), validators.InputRequired()],
+    )
+
     postContent = TextAreaField(
         "Post Content",
         [validators.Length(min=50)],


### PR DESCRIPTION
## Summary
- allow authors to input a short abstract when creating or editing a post
- display the abstract on post cards and in post meta tags
- enforce abstract length via form validation
- keep database schema in sync by adding a new column
- avoid unsafe HTML output when rendering abstracts

## Testing
- `python -m py_compile $(git ls-files '*.py')`

fixes #190 

------
https://chatgpt.com/codex/tasks/task_e_6870296e11b08325b81d96b399fc53cb