### PR TITLE
fix: scope email verification code to the user session

### DIFF
--- a/app/routes/verify_user.py
+++ b/app/routes/verify_user.py
@@ -48,15 +48,13 @@ def verify_user(code_sent):
         if user.is_verified == "True":
             return redirect("/")
         elif user.is_verified == "False":
-            global verification_code
-
             form = VerifyUserForm(request.form)
 
             if code_sent == "true":
                 if request.method == "POST":
                     code = request.form["code"]
 
-                    if code == verification_code:
+                    if code == session.get("verification_code"):
                         user.is_verified = "True"
                         db.session.commit()
 
@@ -92,6 +90,7 @@ def verify_user(code_sent):
                         server.login(Settings.SMTP_MAIL, Settings.SMTP_PASSWORD)
 
                         verification_code = str(randint(1000, 9999))
+                        session["verification_code"] = verification_code
 
                         message = EmailMessage()
                         message.set_content(


### PR DESCRIPTION
The verification code generated in verify_user() was stored in a module-level global variable, so it was shared across every visitor's request. If two users requested a verification email around the same time, the second request's code silently overwrote the first's, making the first user's code invalid before they could use it.

Store the code in the user's own session instead, consistent with how this route already tracks per-user state (session['username'], session['language']). The generated code is now saved to session['verification_code'] right after it is created, and the submitted code is compared against session.get('verification_code') instead of the old global variable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved reliability and security of the account verification process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->