### PR TITLE
fix: redirect anonymous commenters to login instead of crashing

### DIFF
--- a/app/routes/post.py
+++ b/app/routes/post.py
@@ -50,6 +50,13 @@ def post(url_id=None, slug=None):
                 delete_comment(request.form["comment_id"])
                 return redirect(url_for("post.post", url_id=url_id)), 301
 
+            if "username" not in session:
+                Log.error(
+                    f"{request.remote_addr} tried to comment on post: "
+                    f'"{url_id}" without logging in',
+                )
+                return redirect(f"/login/redirect=&post&{url_id}")
+
             comment_text = escape(request.form["comment"])
 
             new_comment = Comment(

--- a/app/routes/post.py
+++ b/app/routes/post.py
@@ -18,6 +18,7 @@ from utils.flash_message import flash_message
 from utils.forms.comment_form import CommentForm
 from utils.generate_url_id_from_post import get_slug_from_post_title
 from utils.log import Log
+from utils.sanitize_for_log import sanitize_for_log
 from utils.time import current_time_stamp
 
 post_blueprint = Blueprint("post", __name__)
@@ -51,9 +52,11 @@ def post(url_id=None, slug=None):
                 return redirect(url_for("post.post", url_id=url_id)), 301
 
             if "username" not in session:
+                safe_remote_addr = sanitize_for_log(request.remote_addr)
+                safe_url_id = sanitize_for_log(url_id)
                 Log.error(
-                    f"{request.remote_addr} tried to comment on post: "
-                    f'"{url_id}" without logging in',
+                    f"{safe_remote_addr} tried to comment on post: "
+                    f'"{safe_url_id}" without logging in',
                 )
                 return redirect(f"/login/redirect=&post&{url_id}")
 

--- a/app/utils/sanitize_for_log.py
+++ b/app/utils/sanitize_for_log.py
@@ -1,0 +1,15 @@
+"""
+This module contains the function to sanitize untrusted values before they are
+written to log output.
+"""
+
+
+def sanitize_for_log(value):
+    """Strip CR/LF characters from a value before it is interpolated into a log message.
+
+    Request-derived values (client IPs, URL segments, etc.) are attacker
+    controlled. Logging them unsanitized lets an attacker inject carriage
+    return / line feed characters and forge fake log lines (CWE-117).
+    """
+
+    return str(value).replace("\r", "").replace("\n", "")


### PR DESCRIPTION
The comment POST handler in post() read session['username'] directly without checking it was set. Any unauthenticated POST to /post/<id> with a comment field (and no delete button fields) raised an unhandled KeyError / 500 instead of failing gracefully.

Add the same not-logged-in guard already used for the post-delete and comment-delete paths in this codebase, redirecting to the login page with a return path, consistent with the &-delimited redirect convention used elsewhere (see login.py, edit_post.py).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Users must now be logged in to post comments. Unauthenticated submission attempts are redirected to login. Functionality for logged-in users remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->