### PR TITLE
fix: enforce CreatePostForm validation on post creation

### DIFF
--- a/app/routes/create_post.py
+++ b/app/routes/create_post.py
@@ -37,14 +37,9 @@ def create_post():
         form = CreatePostForm(request.form)
 
         if request.method == "POST":
-            post_title = request.form["post_title"]
-            post_tags = request.form["post_tags"]
-            post_abstract = request.form["post_abstract"]
-            post_content = request.form["post_content"]
             post_banner = request.files["post_banner"].read()
-            post_category = request.form["post_category"]
 
-            if post_content == "" or post_abstract == "":
+            if not form.validate():
                 flash_message(
                     page="create_post",
                     message="empty",
@@ -52,9 +47,16 @@ def create_post():
                     language=session["language"],
                 )
                 Log.error(
-                    f'User: "{session["username"]}" tried to create a post with empty content',
+                    f'User: "{session["username"]}" tried to create a post with '
+                    f"invalid data: {form.errors}",
                 )
             else:
+                post_title = form.post_title.data
+                post_tags = form.post_tags.data
+                post_abstract = form.post_abstract.data
+                post_content = form.post_content.data
+                post_category = form.post_category.data
+
                 new_post = Post(
                     title=post_title,
                     tags=post_tags,


### PR DESCRIPTION
CreatePostForm was instantiated in create_post() but .validate() was never called, so all its validators (title length, required tags, abstract length, etc.) were silently bypassed. The handler read raw values straight from request.form and only checked that content and abstract were non-empty.

This let a 1-character title or empty tags field through, while the form's own rules (Length(min=4, max=75) on title, InputRequired() on tags/category, Length(min=150, max=200) on abstract) were never enforced.

Validate the form and use its cleaned field data when building the new Post; fall back to the existing 'empty' flash message on failure and log the specific validation errors.