### PR TITLE
fix(#261): safe session language access

### DIFF
--- a/app/routes/change_password.py
+++ b/app/routes/change_password.py
@@ -49,7 +49,7 @@ def change_password():
                 page="change_password",
                 message="login",
                 category="error",
-                language=session["language"],
+                language=session.get("language", "en"),
             )
             return redirect("/login/redirect=change-password")
 
@@ -59,7 +59,7 @@ def change_password():
                     page="change_password",
                     message="same",
                     category="error",
-                    language=session["language"],
+                    language=session.get("language", "en"),
                 )
 
             if password != password_confirm:
@@ -67,7 +67,7 @@ def change_password():
                     page="change_password",
                     message="match",
                     category="error",
-                    language=session["language"],
+                    language=session.get("language", "en"),
                 )
 
             if old_password != password and password == password_confirm:
@@ -93,7 +93,7 @@ def change_password():
                 page="change_password",
                 message="old",
                 category="error",
-                language=session["language"],
+                language=session.get("language", "en"),
             )
 
     return render_template(

--- a/app/routes/change_profile_picture.py
+++ b/app/routes/change_profile_picture.py
@@ -56,7 +56,7 @@ def change_profile_picture():
                 page="change_profile_picture",
                 message="success",
                 category="success",
-                language=session["language"],
+                language=session.get("language", "en"),
             )
 
         return redirect("/account-settings")

--- a/app/routes/change_username.py
+++ b/app/routes/change_username.py
@@ -73,7 +73,7 @@ def change_username():
                 page="change_username",
                 message="success",
                 category="success",
-                language=session["language"],
+                language=session.get("language", "en"),
             )
 
             return redirect("/account-settings")
@@ -83,7 +83,7 @@ def change_username():
                 page="change_username",
                 message="taken",
                 category="error",
-                language=session["language"],
+                language=session.get("language", "en"),
             )
 
     return render_template(

--- a/app/routes/create_post.py
+++ b/app/routes/create_post.py
@@ -49,7 +49,7 @@ def create_post():
                 page="create_post",
                 message="empty",
                 category="error",
-                language=session["language"],
+                language=session.get("language", "en"),
             )
             Log.error(
                 f'User: "{session["username"]}" tried to create a post with '
@@ -87,7 +87,7 @@ def create_post():
                 page="create_post",
                 message="success",
                 category="success",
-                language=session["language"],
+                language=session.get("language", "en"),
             )
             return redirect("/")
 

--- a/app/routes/edit_post.py
+++ b/app/routes/edit_post.py
@@ -64,7 +64,7 @@ def edit_post(url_id):
                         page="edit_post",
                         message="empty",
                         category="error",
-                        language=session["language"],
+                        language=session.get("language", "en"),
                     )
                     Log.error(
                         f'User: "{session["username"]}" tried to edit a post with empty content',
@@ -88,7 +88,7 @@ def edit_post(url_id):
                         page="edit_post",
                         message="success",
                         category="success",
-                        language=session["language"],
+                        language=session.get("language", "en"),
                     )
                     return redirect(f"/post/{post.url_id}")
 
@@ -105,7 +105,7 @@ def edit_post(url_id):
                 page="edit_post",
                 message="author",
                 category="error",
-                language=session["language"],
+                language=session.get("language", "en"),
             )
             Log.error(
                 f'User: "{session["username"]}" tried to edit another authors post',

--- a/app/routes/login.py
+++ b/app/routes/login.py
@@ -64,7 +64,7 @@ def login(direct):
                         page="login",
                         message="not_found",
                         category="error",
-                        language=session["language"],
+                        language=session.get("language", "en"),
                     )
                 else:
                     if encryption.verify(password, user.password):
@@ -76,7 +76,7 @@ def login(direct):
                             page="login",
                             message="success",
                             category="success",
-                            language=session["language"],
+                            language=session.get("language", "en"),
                         )
 
                         return (
@@ -90,7 +90,7 @@ def login(direct):
                             page="login",
                             message="password",
                             category="error",
-                            language=session["language"],
+                            language=session.get("language", "en"),
                         )
 
             return render_template(

--- a/app/routes/password_reset.py
+++ b/app/routes/password_reset.py
@@ -62,7 +62,7 @@ def password_reset(code_sent):
                         page="password_reset",
                         message="not_found",
                         category="error",
-                        language=session["language"],
+                        language=session.get("language", "en"),
                     )
                 else:
                     if password == password_confirm:
@@ -71,7 +71,7 @@ def password_reset(code_sent):
                                 page="password_reset",
                                 message="same",
                                 category="error",
-                                language=session["language"],
+                                language=session.get("language", "en"),
                             )
                         else:
                             password_reset_codes_storage.pop(username)
@@ -84,7 +84,7 @@ def password_reset(code_sent):
                                 page="password_reset",
                                 message="success",
                                 category="success",
-                                language=session["language"],
+                                language=session.get("language", "en"),
                             )
                             return redirect("/login/redirect=&")
                     else:
@@ -92,14 +92,14 @@ def password_reset(code_sent):
                             page="password_reset",
                             message="match",
                             category="error",
-                            language=session["language"],
+                            language=session.get("language", "en"),
                         )
             else:
                 flash_message(
                     page="password_reset",
                     message="wrong",
                     category="error",
-                    language=session["language"],
+                    language=session.get("language", "en"),
                 )
 
         return render_template(
@@ -163,7 +163,7 @@ def password_reset(code_sent):
                     page="password_reset",
                     message="code",
                     category="success",
-                    language=session["language"],
+                    language=session.get("language", "en"),
                 )
                 return redirect("/password-reset/codesent=true")
             else:
@@ -172,7 +172,7 @@ def password_reset(code_sent):
                     page="password_reset",
                     message="not_found",
                     category="error",
-                    language=session["language"],
+                    language=session.get("language", "en"),
                 )
 
         return render_template(

--- a/app/routes/post.py
+++ b/app/routes/post.py
@@ -80,7 +80,7 @@ def post(url_id=None, slug=None):
                 page="post",
                 message="success",
                 category="success",
-                language=session["language"],
+                language=session.get("language", "en"),
             )
 
             return redirect(url_for("post.post", url_id=url_id)), 301

--- a/app/routes/set_language.py
+++ b/app/routes/set_language.py
@@ -24,7 +24,7 @@ def set_language(language):
             page="set_language",
             message="success",
             category="success",
-            language=session["language"],
+            language=session.get("language", "en"),
         )
     else:
         Log.warning(f"Language not supported: {language}")

--- a/app/routes/signup.py
+++ b/app/routes/signup.py
@@ -92,7 +92,7 @@ def signup():
                                 page="signup",
                                 message="success",
                                 category="success",
-                                language=session["language"],
+                                language=session.get("language", "en"),
                             )
 
                             # Send welcome email (with error handling)
@@ -157,7 +157,7 @@ def signup():
                                 page="signup",
                                 message="ascii",
                                 category="error",
-                                language=session["language"],
+                                language=session.get("language", "en"),
                             )
                     else:
                         Log.error("Passwords do not match")
@@ -166,7 +166,7 @@ def signup():
                             page="signup",
                             message="password",
                             category="error",
-                            language=session["language"],
+                            language=session.get("language", "en"),
                         )
 
                 if username_taken and email_taken:
@@ -175,7 +175,7 @@ def signup():
                         page="signup",
                         message="taken",
                         category="error",
-                        language=session["language"],
+                        language=session.get("language", "en"),
                     )
                 if not username_taken and email_taken:
                     Log.error(f'This email "{email}" is unavailable')
@@ -184,7 +184,7 @@ def signup():
                         page="signup",
                         message="email",
                         category="error",
-                        language=session["language"],
+                        language=session.get("language", "en"),
                     )
 
                 if username_taken and not email_taken:
@@ -194,7 +194,7 @@ def signup():
                         page="signup",
                         message="username",
                         category="error",
-                        language=session["language"],
+                        language=session.get("language", "en"),
                     )
 
             return render_template(

--- a/app/routes/verify_user.py
+++ b/app/routes/verify_user.py
@@ -64,7 +64,7 @@ def verify_user(code_sent):
                         page="verify_user",
                         message="success",
                         category="success",
-                        language=session["language"],
+                        language=session.get("language", "en"),
                     )
                     return redirect("/")
                 else:
@@ -72,7 +72,7 @@ def verify_user(code_sent):
                         page="verify_user",
                         message="wrong",
                         category="error",
-                        language=session["language"],
+                        language=session.get("language", "en"),
                     )
 
             return render_template(

--- a/app/utils/delete.py
+++ b/app/utils/delete.py
@@ -55,7 +55,7 @@ def delete_post(post_id, username=None):
         page="delete",
         message="post",
         category="error",
-        language=session["language"],
+        language=session.get("language", "en"),
     )
     Log.success(f'Post: "{post_id}" deleted by "{username}"')
     return True
@@ -89,7 +89,7 @@ def delete_user(username):
         page="delete",
         message="user",
         category="error",
-        language=session["language"],
+        language=session.get("language", "en"),
     )
     Log.success(f'User: "{username}" deleted')
 
@@ -134,7 +134,7 @@ def delete_comment(comment_id, username=None):
         page="delete",
         message="comment",
         category="error",
-        language=session["language"],
+        language=session.get("language", "en"),
     )
     Log.success(f'Comment: "{comment_id}" deleted by "{username}"')
     return True


### PR DESCRIPTION
> 🤖 AI-generated change (local LLM via Hermes Agent). Not human-reviewed. Draft — do not merge without author review.

## What changed

Replaced all unsafe `session["language"]` reads with `session.get("language", "en")` across 12 files. This prevents a `KeyError` (and 500 Internal Server Error) when the session language key is missing due to corruption, migration, or edge cases.

## Files touched

- `app/routes/change_password.py`
- `app/routes/change_profile_picture.py`
- `app/routes/change_username.py`
- `app/routes/create_post.py`
- `app/routes/edit_post.py`
- `app/routes/login.py`
- `app/routes/password_reset.py`
- `app/routes/post.py`
- `app/routes/set_language.py`
- `app/routes/signup.py`
- `app/routes/verify_user.py`
- `app/utils/delete.py`

## Write sites left untouched

`app/utils/before_request/browser_language.py` and `app/routes/set_language.py` contain `session["language"] = ...` assignments. These were intentionally left as bracket assignments since they are write operations, not reads.

## Testing

- All changed files compile cleanly (`py_compile` verified).
- Post-change grep confirms only write assignments (`session["language"] =`) remain in the codebase — zero unsafe reads left.
- Full Playwright e2e suite was NOT run locally (no browser available in this sandbox). The CI workflow `e2e-tests.yaml` will cover e2e validation on merge.

Closes #261


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved language handling across login, signup, profile, post, password reset, verification, and deletion flows.
  * Messages now fall back to English when a language preference is missing, preventing errors and keeping user feedback visible.
  * Applied the same safeguard to both success and error notifications in affected actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->