### PR TITLE
fix(#265): uniform error messages for auth failures

### DIFF
--- a/app/routes/login.py
+++ b/app/routes/login.py
@@ -62,7 +62,7 @@ def login(direct):
                     Log.error(f'User: "{username}" not found')
                     flash_message(
                         page="login",
-                        message="not_found",
+                        message="password",
                         category="error",
                         language=session.get("language", "en"),
                     )

--- a/app/routes/password_reset.py
+++ b/app/routes/password_reset.py
@@ -170,7 +170,7 @@ def password_reset(code_sent):
                 Log.error(f'User: "{username}" with email: "{email}" not found')
                 flash_message(
                     page="password_reset",
-                    message="not_found",
+                    message="wrong",
                     category="error",
                     language=session.get("language", "en"),
                 )


### PR DESCRIPTION
## Fix for #265: CWE-204 - Observable response discrepancy

### What Changed
- `app/routes/login.py`: Unified error messages for "user not found" and "wrong password" — both now use `message="password"`
- `app/routes/password_reset.py`: Unified error messages for "user not found" — changed from `message="not_found"` to `message="wrong"` (matches the existing "wrong code" message)

### Files Changed
- `app/routes/login.py` (line 65)
- `app/routes/password_reset.py` (line 173)

### Deliberately Left Untouched
- Password reset code generation (line 128)
- Email sending logic (lines 122-158)
- Password hash verification (line 69)
- `password_reset.py` line 63: `not_found` message in the code-verified path (not a user enumeration vector — requires a valid reset code first)

### Notes
- This PR was opened as DRAFT for human review.
- Local E2E tests could not run (no browser available).
- All changed files pass `py_compile` verification.

Closes #265
